### PR TITLE
Remove mentions of 'affiliated' from various files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 ====================
 PopStar
 ====================
-PopStar is an astropy affiliated package for generating simple stellar populations from synthetic evolution and atmosphere models. Currently, PopStar generates single-age, single-metallicity populations (i.e. star clusters). It supports different initial mass functions, multiplicity perscriptions, reddening laws, filter functions, atmosphere models, and evolution models. The pacakge is object oriented and is extensible. 
+PopStar is a package for generating simple stellar populations from synthetic evolution and atmosphere models. Currently, PopStar generates single-age, single-metallicity populations (i.e. star clusters). It supports different initial mass functions, multiplicity perscriptions, reddening laws, filter functions, atmosphere models, and evolution models. The pacakge is object oriented and is extensible. 
 
 PopStar's primary strength is the large set of models that are accessible. In particular, we have created a set of models that "merge" the best-in-class evolution and atmosphere models to cover the full range of masses from 0.08 - 150 Msun at very young ages, including pre-main-sequence evolution.
 
@@ -72,7 +72,7 @@ can download from here:
 GIT SITE -- load these up
 /g/lu/models/cdbs
 
-Ready: 
+Ready:
 
 * phoenix\_v16 - high resolution (reformatted for CDBS)
 * phoenix\_v16_rebin - downgraded to improve synthetic photometry
@@ -88,20 +88,20 @@ is done in two steps.
 In your .cshrc or .bashrc, set the PYSYN_CDBS and POPSTAR_MODELS variables:
 
     setenv PYSYN_CDBS /g/lu/models/cdbs
-    
+
     setenv POPSTAR_MODELS /g/lu/models
 
 or
 
     export PYSYN_CDBS=/g/lu/models/cdbs
-    
+
     export POPSTAR_MODELS=/g/lu/models
 
 Quick Start Guide
 -------------------
 For a quick tutorial on how to make a star cluster with popstar, see
 the jupyter notebook at Popstar/docs/Quick_Start_Make_Cluster.ipynb
-    
+
 
 Other Resources
 ===============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,8 +2,7 @@
 PopStar Package
 ****************
 
-This is an affiliated package for the AstroPy package. The documentation for
-this package is here:
+The documentation for this package is here:
 
 .. toctree::
   :maxdepth: 2
@@ -12,15 +11,14 @@ this package is here:
 
 Indices and tables
 ==================
- 
+
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-  
+
 .. note:: The layout of this directory is simply a suggestion.  To follow
           traditional practice, do *not* edit this page, but instead place
-          all documentation for the affiliated package inside ``packagename/``.
-          The traditional practice was intended to allow the affiliated
+          all documentation for the package inside ``packagename/``.
+          The traditional practice was intended to allow the
           package to eventually be merged into the main astropy package.
           You can follow this practice or choose your own layout.
-                

--- a/licenses/README.rst
+++ b/licenses/README.rst
@@ -1,5 +1,5 @@
 Licenses
 ========
 
-This directory holds license and credit information for the affiliated package,
-works the affiliated package is derived from, and/or datasets.
+This directory holds license and credit information for the package,
+works the package is derived from, and/or datasets.

--- a/popstar/__init__.py
+++ b/popstar/__init__.py
@@ -1,10 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-"""
-This is an Astropy affiliated package.
-"""
-
-# Affiliated packages may add whatever they like to this file, but
+# Packages may add whatever they like to this file, but
 # should keep this content at the top.
 # ----------------------------------------------------------------------------
 from ._astropy_init import *

--- a/popstar/data/README.rst
+++ b/popstar/data/README.rst
@@ -1,7 +1,6 @@
 Data directory
 ==============
 
-This directory contains data files included with the affiliated package source
+This directory contains data files included with this package's source
 code distribution. Note that this is intended only for relatively small files
 - large files should be externally hosted and downloaded as needed.
-

--- a/popstar/extern/__init__.py
+++ b/popstar/extern/__init__.py
@@ -1,8 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-This packages contains python packages that are bundled with the affiliated
-package but are external to the affiliated package, and hence are developed in
-a separate source tree. Note that this package is distinct from the /cextern
-directory of the source code distribution, as that directory only contains C
-extension code.
+This packages contains python packages that are bundled with this package but
+are external to this package, and hence are developed in a separate source tree.
+Note that this package is distinct from the /cextern directory of the source
+code distribution, as that directory only contains C extension code.
 """

--- a/popstar/tests/__init__.py
+++ b/popstar/tests/__init__.py
@@ -1,9 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-This packages contains affiliated package tests.
+This packages contains package tests.
 """
+
 def test_evolution_merged_pisa_ekstrom():
-    """Test the MergedPisaEkstromParsec() class in 
+    """Test the MergedPisaEkstromParsec() class in
     evolution.py
     """
 
@@ -18,6 +19,3 @@ def test_evolution_merged_pisa_ekstrom():
     assert iso1['mass'].max() > iso2['mass'].max()
 
     return
-    
-    
-    


### PR DESCRIPTION
The Astropy [package-template](https://github.com/astropy/package-template) used to (incorrectly) use wording that suggested that packages created using it were automatically affiliated packages - however, this isn't correct as we have a formal process for packages becoming affiliated (the offending language has since been updated in the package-template).

While this repo is in the astropy organization, this does not automatically make it affiliated, as it first needs to go through the process described [here](http://www.astropy.org/affiliated/index.html#affiliated-instructions) to become affiliated. Just to be clear, this is not to say that this package wouldn't be accepted if it applied, but more that it should go through the process like other packages for fairness.