### PR TITLE
Bugfix

### DIFF
--- a/docs/add_filters.rst
+++ b/docs/add_filters.rst
@@ -3,13 +3,17 @@
 ========================================
 Adding Photometric Filters
 ========================================
-If the user wants to add new photometric filters to PyPopStar, there are 3 main steps:
+If the user wants to add new photometric filters to PyPopStar, there are 4 main steps:
 
   1) Save the filter transmissions as text files in a new sub-directory in the top-level ``filt_func`` directory.
   2) Define a new function in ``filters.py`` that reads a unique filter string the user assigns to the new filters,
      and then read the appropriate data files from the new ``filt_func`` sub-directory. 
-  3) Edit the ``get_filter_info()`` function  in ``synthetic.py`` to call the new function in ``filters.py`` when the new filter string is called.
-
+  3) Edit the ``get_filter_info()`` function  in ``synthetic.py`` to
+     call the new function in ``filters.py`` when the new filter
+     string is called.
+   4) Edit the ``get_obs_str()`` function in ``synthetic.py`` to
+      convert between column name and filter string (e.g input string
+      for get_filter_info) for the new filters.
 
 Additional documentation on this is coming soon. In the meantime, let us know on the  Github `issue tracker
 <https://github.com/astropy/PyPopStar/issues>`_ if you'd like to

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -79,10 +79,8 @@ Note that three sets are available: the pre-launch passbands used in DR1
 (`Jordi+10
 <https://ui.adsabs.harvard.edu/abs/2010A%26A...523A..48J/abstract>`_),
 the passbands used for the DR2 published photometry, and
-the *revised* DR2 passbands based on the DR2 data (October 2017). The
-user specifies which one they want by 'dr1', 'dr2', or 'dr2_rev', respectively.
-
-To calculate synthetic fluxes, the dr2_rev passbands are advised.
+the *revised* DR2 passbands based on the DR2 data (October 2017).
+ONLY THE REVISED DR2 PASSBANDS ARE SUPPORTED BY PYPOPSTAR.
 
 Filters: G, Gbp, Grp
 

--- a/popstar/filters.py
+++ b/popstar/filters.py
@@ -334,11 +334,19 @@ def get_keck_osiris_filt(name):
 
 def get_gaia_filt(version, name):
     """
-    Define Gaia filters as pysynphot object
+    Define Gaia filters as pysynphot object.
+    To avoid confusion, we will only support 
+    the revised DR2 zeropoints from 
+    Evans+18.
 
     version: specify dr1, dr2, or dr2_rev
     name: filter name
     """
+    # Assert that we are using the revised DR2 zeropoints
+    if version != 'dr2_rev':
+        msg = 'Gaia version {0} not supported, use dr2_rev instead'.format(version)
+        raise ValueError(msg)
+
     # Set the filter directory
     if version == 'dr1':
         path = '{0}/gaia/dr1/'.format(filters_dir)

--- a/popstar/synthetic.py
+++ b/popstar/synthetic.py
@@ -1470,7 +1470,11 @@ def get_filter_col_name(obs_str):
     tmp = obs_str.split(',')
 
     if len(tmp) == 3:
-        filt_name = 'hst_{0}'.format(tmp[-1])
+        # Catch Gaia filter cases. Otherwise, it is HST filter
+        if 'dr2_rev' in tmp:
+            filt_name = 'gaiaDR2_{0}'.format(tmp[-1])
+        else:
+            filt_name = 'hst_{0}'.format(tmp[-1])
     else:
         filt_name = '{0}_{1}'.format(tmp[0], tmp[1])
         
@@ -1515,6 +1519,7 @@ def get_obs_str(col):
                  'jwst_F405N': 'jwst,F405N',
                  'jwst_F410M': 'jwst,F410M',
                  'jwst_F430M': 'jwst,F430M',
+                 'jwst_F444W': 'jwst,F444W',
                  'jwst_F440W': 'jwst,F440W',
                  'jwst_F460M': 'jwst,F460M',
                  'jwst_F470N': 'jwst,F470N',
@@ -1522,9 +1527,17 @@ def get_obs_str(col):
                  'nirc2_J': 'nirc2,J', 'nirc2_H': 'nirc2,H', 'nirc2_Kp': 'nirc2,Kp', 'nirc2_K': 'nirc2,K',
                  'nirc2_Lp': 'nirc2,Lp', 'nirc2_Ms': 'nirc2,Ms', 'nirc2_Hcont': 'nirc2,Hcont',
                  'nirc2_FeII': 'nirc2,FeII', 'nirc2_Brgamma': 'nirc2,Brgamma',
+                 '2mass_J': '2mass,J', '2mass_H': '2mass,H', '2mass_Ks': '2mass,Ks',
+                 'ubv_U':'ubv,U', 'ubv_B':'ubv,B', 'ubv_V':'ubv,V', 'ubv_R':'ubv,R',
+                 'ubv_I':'ubv,I', 
                  'jg_J': 'jg,J', 'jg_H': 'jg,H', 'jg_K': 'jg,K',
-                 'nirc1_K':'nirc1,K', 'ctio_osiris_K': 'ctio_osirirs,K',
-                 'ztf_g':'ztf,g', 'ztf_r':'ztf,r', 'ztf_i':'ztf,i'}
+                 'nirc1_K':'nirc1,K', 'nirc1_H':'nirc1,H',
+                 'naco_J':'naco,J', 'naco_H':'naco,H', 'naco_Ks':'naco,Ks',
+                 'ukirt_J':'ukirt,J', 'ukirt_H':'ukirt,H', 'ukirt_K':'ukirt,K',
+                 'ctio_osiris_H': 'ctio_osiris,H', 'ctio_osiris_K': 'ctio_osiris,K',
+                 'ztf_g':'ztf,g', 'ztf_r':'ztf,r', 'ztf_i':'ztf,i',
+                 'gaiaDR2_G': 'gaia,dr2_rev,G', 'gaiaDR2_Gbp':'gaia,dr2_rev,Gbp',
+                 'gaiaDR2_Grp':'gaia,dr2_rev,Grp'}
 
     obs_str = filt_list[name]
         

--- a/popstar/tests/test_models.py
+++ b/popstar/tests/test_models.py
@@ -125,13 +125,27 @@ def test_filters():
                      'vista,Y', 'vista,Z', 'vista,J',
                      'vista,H',  'vista,Ks', 'ztf,g', 'ztf,r', 'ztf,i']
 
-    # Loop through filters to test that they work
+    # Loop through filters to test that they work: get_filter_info
     for ii in filt_list:
         try:
             filt = synthetic.get_filter_info(ii, rebin=True, vega=vega)
         except:
-            print('TEST FAILED for {0}'.format(ii))
+            print('get_filter_info TEST FAILED for {0}'.format(ii))
 
+    print('get_filter_info pass')
+    
+    # Loop through filters to test that they work: get_obs_str
+    for ii in filt_list:
+        try:
+            # Test going from col_name to obs_str
+            col_name = synthetic.get_filter_col_name(ii)
+            obs_str = synthetic.get_obs_str('m_{0}'.format(col_name))
+            # Does the obs_str work?
+            filt_info = synthetic.get_filter_info(obs_str)
+        except:
+            print('get_obs_str TEST FAILED for {0}'.format(ii)) 
+            
+    print('get_obs_str pass')
     print('Filters done')
 
     return


### PR DESCRIPTION
Fix bugs related to Gaia DR2 filters column names and missing filter strings within ResolvedClusterDiffRedden function. Specific fixes:

-Gaia photometry column names changed to 'm_gaiaDR2_<filter>'
-missing photometric strings in synthetic.get_obs_str() function added
-updated filters.py to ensure that only the revised DR2 passbands are ever used
-updated documentation for Gaia filters to emphasize that only revised DR2 passbands supported
-Updated documentation for adding filters to add that user needs to edit synthetic.get_obs_str() as well
-Improved test function test_models.test_filters() to catch failure modes with Gaia columns, missing photometric strings in synthetic.get_obs_str()